### PR TITLE
plugin-erstellen.md | Link korrigiert & Link ergänzt

### DIFF
--- a/plugin-erstellen.md
+++ b/plugin-erstellen.md
@@ -84,4 +84,5 @@ Um Plugins in moziloCMS zu entwickeln braucht es also nicht viel. An sich reicht
 
 ## Siehe auch
 
+- http://www.mozilo.de/moziloCMS%202.0/Plugin%20Entwickler.html
 - http://www.mozilo.de/Entwicklerportal/Plugins%20programmieren.html

--- a/plugin-erstellen.md
+++ b/plugin-erstellen.md
@@ -84,4 +84,4 @@ Um Plugins in moziloCMS zu entwickeln braucht es also nicht viel. An sich reicht
 
 ## Siehe auch
 
-- http://www.mozilo.de/Entwicklerportal/Plugins programmieren.html
+- http://www.mozilo.de/Entwicklerportal/Plugins%20programmieren.html


### PR DESCRIPTION
# `plugin-erstellen.md`

## Link korrigiert

` ` (Leerzeichen) im Pfad durch `%20` ersetzt.

## Link ergänzt

Entwickler-Dokumentation: Plugin für moziloCMS 2.0